### PR TITLE
Update version of seaside to 3.3.x

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'repository'
+}

--- a/repository/.properties
+++ b/repository/.properties
@@ -1,0 +1,3 @@
+{
+	#format : #filetree
+}

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -7,7 +7,7 @@ baseline: spec
 			baseline: 'Seaside3' with: [
 				spec
 					loads: #('Tests' 'Zinc-Seaside');
-					repository: 'github://SeasideSt/Seaside/repository'];
+					repository: 'github://SeasideSt/Seaside:v3.3.x/repository'];
 				
 			baseline: 'Ston' with: [
 				spec

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -7,7 +7,7 @@ baseline: spec
 			baseline: 'Seaside3' with: [
 				spec
 					loads: #('Tests' 'Zinc-Seaside');
-					repository: 'github://SeasideSt/Seaside:v3.3.x/repository'];
+					repository: 'github://SeasideSt/Seaside:v3.3.2/repository'];
 				
 			baseline: 'Ston' with: [
 				spec

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -7,7 +7,7 @@ baseline: spec
 			baseline: 'Seaside3' with: [
 				spec
 					loads: #('Tests' 'Zinc-Seaside');
-					repository: 'github://SeasideSt/Seaside:v3.3.2/repository'];
+					repository: 'github://SeasideSt/Seaside:v3.3.4/repository'];
 				
 			baseline: 'Ston' with: [
 				spec

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -7,7 +7,7 @@ baseline: spec
 			baseline: 'Seaside3' with: [
 				spec
 					loads: #('Tests' 'Zinc-Seaside');
-					repository: 'github://SeasideSt/Seaside:v3.3.2/repository'];
+					repository: 'github://SeasideSt/Seaside:v3.3.x/repository'];
 				
 			baseline: 'Ston' with: [
 				spec

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -7,7 +7,7 @@ baseline: spec
 			baseline: 'Seaside3' with: [
 				spec
 					loads: #('Tests' 'Zinc-Seaside');
-					repository: 'github://SeasideSt/Seaside:v3.3.4/repository'];
+					repository: 'github://SeasideSt/Seaside:v3.3.2/repository'];
 				
 			baseline: 'Ston' with: [
 				spec


### PR DESCRIPTION
Update the version of Seaside, so as not to have dependency conflicts between MaterialDesignLite and Magritte (these use 3.3.x version of Seaside)