### PR TITLE
This should make connecting to a selenium cloud grid possible. (works with Browserstack)

### DIFF
--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/password..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/password..st
@@ -1,0 +1,3 @@
+accessing
+password: aPassword 
+	Password := aPassword

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/password.st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/password.st
@@ -1,0 +1,3 @@
+accessing
+password
+	^ Password ifNil: [ '' ]

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/scheme..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/scheme..st
@@ -1,0 +1,3 @@
+accessing
+scheme: aScheme 
+	Scheme := aScheme

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/scheme.st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/scheme.st
@@ -1,0 +1,3 @@
+accessing
+scheme
+	^ Scheme ifNil: [ 'http' ]

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/username..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/username..st
@@ -1,0 +1,3 @@
+accessing
+username: aUsername
+	Username := aUsername

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/username.st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/class/username.st
@@ -1,0 +1,3 @@
+accessing
+username
+	^ Username ifNil: [ '' ]

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/baseDriverURL.st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/baseDriverURL.st
@@ -1,5 +1,11 @@
 accessing
 baseDriverURL
-
-	^'http://' , self class serverHost , ':'
-		, self class serverPort printString , '/wd/hub/'
+	| credentialString |
+	credentialString := self class username.
+	credentialString := self class password
+		ifNotEmpty: [ :password | credentialString , ':' , password ].
+	credentialString := credentialString
+		ifNotEmpty: [ credentialString , '@' ].
+	^ self class scheme , '://' , credentialString
+		, self class serverHost , ':' , self class serverPort printString
+		, '/wd/hub/'

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/handleResponse..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/handleResponse..st
@@ -1,6 +1,9 @@
 private
 handleResponse: response
-
-	(response httpStatus ~= 204) ifTrue: [
-		self handleResponse: response onSuccess: [ :result | (result at: 'value') ifNotNil: [ self error: 'Value unexpectedly not JSON null' ] ].
-	]
+	response httpStatus ~= 204
+		ifTrue: [ self
+				handleResponse: response
+				onSuccess: [ :result | 
+					(result at: 'value')
+						ifNotNil:
+							[ :value | value ifNotEmpty: [ self error: 'Value unexpectedly not JSON null' ] ] ] ]

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/initWithCapabilities..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/initWithCapabilities..st
@@ -1,11 +1,15 @@
 initialize-release
 initWithCapabilities: desiredCapabilities
-
-	| response |
+	| response parsedResponse |
 	self initialize.
 	response := self
-				httpPost: self baseDriverURL , 'session'
-				jsonData: desiredCapabilities privateSessionCreationJSON
-				timeout: 120.
+		httpPost: self baseDriverURL , 'session'
+		jsonData: desiredCapabilities privateSessionCreationJSON
+		timeout: 120.
 	sessionID := self sessionIdFromResponse: response.
-	capabilities := BPCapabilities withDictionary: (((BPSmalltalkPlatform current jsonRead: response contents) at: 'value') at: 'capabilities').
+	parsedResponse := self parseResponse: response.
+	capabilities := BPCapabilities
+		withDictionary:
+			((parsedResponse at: 'value')
+				at: 'capabilities'
+				ifAbsent: [ parsedResponse at: 'value' ])

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/parseResponse..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/parseResponse..st
@@ -1,0 +1,6 @@
+initialize-release
+parseResponse: response
+	| parsedResponse |
+	parsedResponse := BPSmalltalkPlatform current
+		jsonRead: response contents.
+	^ parsedResponse

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/sessionIdFromResponse..st
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/instance/sessionIdFromResponse..st
@@ -1,6 +1,12 @@
 initialize-release
 sessionIdFromResponse: response
-
-	response httpStatus = 200 ifTrue: [
-		^ ((BPSmalltalkPlatform current jsonRead: response contents) at: 'value') at: 'sessionId' ].
-	self error: 'Unexpected response status code ' , response httpStatus printString , ' while creating web driver session.'
+	| parsedResponse |
+	response httpStatus = 200
+		ifTrue: [ parsedResponse := self parseResponse: response.
+			^ parsedResponse
+				at: 'sessionId'
+				ifAbsent: [ (parsedResponse at: 'value') at: 'sessionId' ] ].
+	self
+		error:
+			'Unexpected response status code ' , response httpStatus printString
+				, ' while creating web driver session.'

--- a/repository/Parasol-Core.package/BPRemoteWebDriver.class/properties.json
+++ b/repository/Parasol-Core.package/BPRemoteWebDriver.class/properties.json
@@ -5,8 +5,11 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [
+		"Password",
+		"Scheme",
 		"ServerHost",
-		"ServerPort"
+		"ServerPort",
+		"Username"
 	],
 	"instvars" : [
 		"capabilities",


### PR DESCRIPTION
Hello guys,

Please consider the following contribution. 
The goal is to make Parasol compatible with the Browserstack solution.
If you have a browserstack account, you can set up your web browser driver this way 
```
BPRemoteWebDriver serverHost: 'hub-cloud.browserstack.com'.
BPRemoteWebDriver username: 'username'.
BPRemoteWebDriver password: 'yourkey'.
BPRemoteWebDriver scheme: 'https'.
BPRemoteWebDriver serverPort: 443.
option := BPChromeOptions new.
driver := BPRemoteWebDriver new initWithCapabilities: option.
driver quit.
```

The code might look a little bit janky but the official selenium python remote webdriver, does the same weird [dirty thing](https://github.com/SeleniumHQ/selenium/blob/trunk/py/selenium/webdriver/remote/webdriver.py#L282).
