### PR TITLE
Issue 41

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# inform linguist that files with these extensions are indeed smalltalk files
+*.st linguist-language=Smalltalk
+*.gs linguist-language=Smalltalk

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 Session.vim
 .netrwhist
 *~
+*.jar
+*.zip
+*.log
+*.txt
+*.lck
+chromedriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ smalltalk:
   - Pharo-5.0
   - Squeak64-5.2
   - Squeak-5.2
-  - GemStone-3.5.0
-  - GemStone-3.4.2
-  - GemStone-3.3.3
-  - GemStone-3.2.15
+  - GemStone-3.5.3
+  - GemStone-3.4.5
+  - GemStone-3.3.9
+  - GemStone-3.2.17
   - GemStone-3.1.0.6
 
 matrix:

--- a/bin/launchChromeDriver.sh
+++ b/bin/launchChromeDriver.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+#	Script for downloading and launching the ChromeDriver
+#		The ChromeDriver needs to be running if you want to run the 
+#		WAWebDriverFunctionalTestCase tests
+#
+#	This script is based on the .travis.yml script, the .travis.yml is the master
+#		implementation
+#
+#	1. java is assumed to be on your path.
+#	2. The CHROME_DRIVER_VERSION must match the version of Chrome that is installed
+#			on your machine. 
+#	3. You are responsible for cleaning up the .jar, .zip, .log, .txt, .lck, and
+#			chromedriver files that are created in the directory where you launch
+#			the script: 
+#				rm -f chromedriver chromedriver_linux64.zip seleniumlog.txt selenium-server-standalone-3.141.59.jar
+# 4. You are responsible for killing the java process when you are done
+#			running tests.
+#
+
+if [ "$CHROME_DRIVER_VERSION"x = "x" ] ; then
+	CHROME_DRIVER_VERSION=85.0.4183.87
+fi
+
+if [ ! -d "selenium-server-standalone-3.141.59.jar" ] ; then
+	# download launch theselenium web driver
+	wget http://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
+	wget https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip
+	unzip chromedriver_linux64.zip
+fi
+
+# LAUNCH the web driver
+java -Dwebdriver.chrome.driver=chromedriver -Dwebdriver.chrome.logfile=chromedriver.log -Dwebdriver.chrome.args=--verbose -jar selenium-server-standalone-3.141.59.jar -port 4444 -log seleniumlog.txt &

--- a/repository/Parasol-GemStone.package/CharacterCollection.extension/instance/substrings..st
+++ b/repository/Parasol-GemStone.package/CharacterCollection.extension/instance/substrings..st
@@ -1,4 +1,0 @@
-*Parasol-GemStone
-substrings: separators 
-
-	^self subStrings: separators


### PR DESCRIPTION
fix #41; bin/launchChromeDriver.sh script for manually launching the ChromeDriver when running local Parasol tests; .gitattributes (.st files are treated as http files without it); .gitignore; and update the travis lineup with latest gemstone versions