### PR TITLE
Fix "Infinite load loop involving Seaside and Parasol when reloading either project - GemStone only"

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,8 +1,10 @@
 SmalltalkCISpec {
-  #preloading : SCICustomScript {
-    #path : 'scripts/preloadSeasideForGemStone.st',
-    #platforms : [ #gemstone ]
-	},
+  #preloading :  [ 
+    SCICustomScript {
+      #path : 'scripts/preloadSeasideForGemStone.st',
+      #platforms : [ #gemstone ]
+    }
+	],
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'Parasol',

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,5 +1,5 @@
 SmalltalkCISpec {
-  #preloading :  [ 
+  #preLoading :  [ 
     SCICustomScript {
       #path : 'scripts/preloadSeasideForGemStone.st',
       #platforms : [ #gemstone ]

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,4 +1,8 @@
 SmalltalkCISpec {
+  #preloading : SCICustomScript {
+    #path : 'scripts/preloadSeasideForGemStone.st',
+    #platforms : [ #gemstone ]
+	},
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'Parasol',

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,20 @@ before_script:
   - "java -Dwebdriver.chrome.driver=chromedriver -jar selenium-server-standalone-3.141.59.jar -port 4444 > /tmp/seleniumlog.&"
 
 smalltalk:
-#  - Pharo64-alpha
-#  - Pharo64-9.0
+  - Pharo64-alpha
+  - Pharo64-9.0
   - Pharo64-8.0
-#  - Pharo64-7.0
-#  - Pharo64-6.1
-#  - Pharo-6.1
-#  - Pharo-5.0
+  - Pharo64-7.0
+  - Pharo64-6.1
+  - Pharo-6.1
+  - Pharo-5.0
   - Squeak64-5.2
-#  - Squeak-5.2
+  - Squeak-5.2
   - GemStone-3.5.3
-#  - GemStone-3.4.5
-#  - GemStone-3.3.9
-#  - GemStone-3.2.17
-#  - GemStone-3.1.0.6
+  - GemStone-3.4.5
+  - GemStone-3.3.9
+  - GemStone-3.2.17
+  - GemStone-3.1.0.6
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,20 @@ before_script:
   - "java -Dwebdriver.chrome.driver=chromedriver -jar selenium-server-standalone-3.141.59.jar -port 4444 > /tmp/seleniumlog.&"
 
 smalltalk:
-  - Pharo64-alpha
-  - Pharo64-9.0
+#  - Pharo64-alpha
+#  - Pharo64-9.0
   - Pharo64-8.0
-  - Pharo64-7.0
-  - Pharo64-6.1
-  - Pharo-6.1
-  - Pharo-5.0
+#  - Pharo64-7.0
+#  - Pharo64-6.1
+#  - Pharo-6.1
+#  - Pharo-5.0
   - Squeak64-5.2
-  - Squeak-5.2
+#  - Squeak-5.2
   - GemStone-3.5.3
-  - GemStone-3.4.5
-  - GemStone-3.3.9
-  - GemStone-3.2.17
-  - GemStone-3.1.0.6
+#  - GemStone-3.4.5
+#  - GemStone-3.3.9
+#  - GemStone-3.2.17
+#  - GemStone-3.1.0.6
 
 matrix:
   allow_failures:

--- a/bin/launchChromeDriver.sh
+++ b/bin/launchChromeDriver.sh
@@ -22,7 +22,7 @@ if [ "$CHROME_DRIVER_VERSION"x = "x" ] ; then
 	CHROME_DRIVER_VERSION=85.0.4183.87
 fi
 
-if [ ! -d "selenium-server-standalone-3.141.59.jar" ] ; then
+if [ ! -f "selenium-server-standalone-3.141.59.jar" ] ; then
 	# download launch theselenium web driver
 	wget http://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
 	wget https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -4,18 +4,13 @@ baseline: spec
 	<baseline>
 	spec for: #common do: [
 		spec 
-			baseline: 'Seaside3' with: [
-				spec
-					loads: #('Tests' 'Zinc-Seaside');
-					repository: 'github://SeasideSt/Seaside/repository'];
-				
 			baseline: 'Ston' with: [
 				spec
 					repository: 'github://svenvc/ston/repository'].
 				
 		spec
 			package: 'Parasol-Core';
-			package: 'Parasol-Seaside' with: [ spec requires: #('Seaside3' 'Parasol-Core') ];
+			package: 'Parasol-Seaside' with: [ spec requires: #('Parasol-Core') ];
 			package: 'Parasol-Tests' with: [ spec requires: #('Parasol-Seaside') ];
 			package: 'Parasol-Convenience' with: [ spec requires: #('Parasol-Core') ].
 			
@@ -23,6 +18,15 @@ baseline: spec
 			group: 'default' with: #('Parasol-Seaside' 'Parasol-Convenience');
 			group: 'core' with: #('Parasol-Core' 'Parasol-Convenience');
 			group: 'tests' with: #('Parasol-Tests' 'default').
+	].
+
+	spec for: #squeakcommon do: [
+		spec 
+			baseline: 'Seaside3' with: [
+				spec
+					loads: #('Tests');
+					repository: 'github://SeasideSt/Seaside/repository'];
+			package: 'Parasol-Seaside' with: [ spec requires: #('Seaside3') ].
 	].
 
 	spec for: #squeak do: [
@@ -36,6 +40,9 @@ baseline: spec
 	].
 
 	spec for: #pharo do: [
+		spec
+			project: 'Seaside3' 
+			with: [ spec loads: #('Tests' 'Zinc-Seaside') ].
 		"Sets the Zinc prerequisite for Pharo"
 			spec 
 				baseline: 'ZincHTTPComponents'

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -20,19 +20,13 @@ baseline: spec
 			group: 'tests' with: #('Parasol-Tests' 'default').
 	].
 
-	spec for: #squeakcommon do: [
+	spec for: #squeak do: [
 		spec 
 			baseline: 'Seaside3' with: [
 				spec
-					loads: #('Tests');
+					loads: #('Tests' 'WebClient');
 					repository: 'github://SeasideSt/Seaside/repository'];
 			package: 'Parasol-Seaside' with: [ spec requires: #('Seaside3') ].
-	].
-
-	spec for: #squeak do: [
-		spec
-			project: 'Seaside3' 
-			with: [ spec loads: #('Tests' 'WebClient') ].
 				
 		spec
 			package: 'Parasol-Squeak' with: [ spec requires: #('Parasol-Seaside') ];
@@ -40,9 +34,12 @@ baseline: spec
 	].
 
 	spec for: #pharo do: [
-		spec
-			project: 'Seaside3' 
-			with: [ spec loads: #('Tests' 'Zinc-Seaside') ].
+		spec 
+			baseline: 'Seaside3' with: [
+				spec
+					loads: #('Tests' 'Zinc-Seaside');
+					repository: 'github://SeasideSt/Seaside/repository'];
+			package: 'Parasol-Seaside' with: [ spec requires: #('Seaside3') ].
 		"Sets the Zinc prerequisite for Pharo"
 			spec 
 				baseline: 'ZincHTTPComponents'

--- a/scripts/preloadSeasideForGemStone.st
+++ b/scripts/preloadSeasideForGemStone.st
@@ -4,5 +4,5 @@ Metacello new
  baseline:'Seaside3';
 " repository: 'github://SeasideSt/Seaside:master/repository';"
  repository: 'github://dalehenrich/Seaside:issue_1223/repository';
- load #('Parasol-Tests').
+ load: #('Parasol-Tests' 'Zinc-Seaside').
 System commit.

--- a/scripts/preloadSeasideForGemStone.st
+++ b/scripts/preloadSeasideForGemStone.st
@@ -4,5 +4,5 @@ Metacello new
  baseline:'Seaside3';
 " repository: 'github://SeasideSt/Seaside:master/repository';"
  repository: 'github://dalehenrich/Seaside:issue_1223/repository';
- load: #('Parasol-Tests' 'Zinc-Seaside').
+ load: #('Parasol-Tests' 'Zinc-Seaside' 'Seaside-JSON-Core').
 System commit.

--- a/scripts/preloadSeasideForGemStone.st
+++ b/scripts/preloadSeasideForGemStone.st
@@ -2,7 +2,6 @@
 	reloade loop has been broken. Travis tests require Seaside to be installed, so install Seaside, explicitly"
 Metacello new
  baseline:'Seaside3';
-" repository: 'github://SeasideSt/Seaside:master/repository';"
- repository: 'github://dalehenrich/Seaside:issue_1223/repository';
+ repository: 'github://SeasideSt/Seaside:master/repository';
  load: #('Parasol-Tests' 'Zinc-Seaside' 'Seaside-JSON-Core' 'Javascript-Core').
 System commit.

--- a/scripts/preloadSeasideForGemStone.st
+++ b/scripts/preloadSeasideForGemStone.st
@@ -1,0 +1,8 @@
+"If Seaside loads Parasol and Parasol loads Seaside, an infinite reload loop can occur. For GemStone, the infinite
+	reloade loop has been broken. Travis tests require Seaside to be installed, so install Seaside, explicitly"
+Metacello new
+ baseline:'Seaside3';
+" repository: 'github://SeasideSt/Seaside:master/repository';"
+ repository: 'github://dalehenrich/Seaside:issue_1223/repository';
+ load #('Parasol-Tests').
+System commit.

--- a/scripts/preloadSeasideForGemStone.st
+++ b/scripts/preloadSeasideForGemStone.st
@@ -4,5 +4,5 @@ Metacello new
  baseline:'Seaside3';
 " repository: 'github://SeasideSt/Seaside:master/repository';"
  repository: 'github://dalehenrich/Seaside:issue_1223/repository';
- load: #('Parasol-Tests' 'Zinc-Seaside' 'Seaside-JSON-Core').
+ load: #('Parasol-Tests' 'Zinc-Seaside' 'Seaside-JSON-Core' 'Javascript-Core').
 System commit.


### PR DESCRIPTION
fix #43 - GemStone-specific changes:
1. Parasol does not explicitly load Seaside3 (the source of the infinite oop)
2. Since Parasol tests need to run Seaside web servers to run the tests, the #preload script `scripts/preloadSeasideForGemStone.st` loads the packages needed to run the Seaside web server gems needed for the tests
