### PR TITLE
49 get attribute may return nil using chromedriver 

### DIFF
--- a/repository/Parasol-Core.package/BPWebElement.class/instance/getAttribute..st
+++ b/repository/Parasol-Core.package/BPWebElement.class/instance/getAttribute..st
@@ -1,11 +1,6 @@
 misc
 getAttribute: nameString
-	"
-		https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/WebElement.html#getAttribute(java.lang.String)
-	"
-
-	self
-		flag: 'Check whether this implementation matches the description of the original Java method'.
-	^driver
+	"https://www.w3.org/TR/webdriver/#get-element-attribute"
+	^ driver
 		httpGetHandleResponse: (self baseElementURL , 'attribute/') , nameString
 		onSuccess: [:result | result at: 'value']

--- a/repository/Parasol-Core.package/BPWebElement.class/instance/getProperty..st
+++ b/repository/Parasol-Core.package/BPWebElement.class/instance/getProperty..st
@@ -1,0 +1,6 @@
+misc
+getProperty: nameString
+	"https://www.w3.org/TR/webdriver/#get-element-property"
+	^ driver
+		httpGetHandleResponse: (self baseElementURL , 'property/') , nameString
+		onSuccess: [:result | (result at: 'value') ]

--- a/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testGetAttribute.st
+++ b/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testGetAttribute.st
@@ -3,9 +3,9 @@ testGetAttribute
 
 	| inputField testDiv2 |
 	inputField := driver findElementByID: 'inputField'.
-	self assert: (inputField getAttribute: 'type') = 'text'.
-	self assert: (inputField getAttribute: 'id') = 'inputField'.
+	self assert: (inputField getAttribute: 'type') equals: 'text'.
+	self assert: (inputField getAttribute: 'id') equals: 'inputField'.
 	self assert: (inputField getAttribute: 'attributeThatIsNotSpecified') isNil.
-	self assert: (inputField getAttribute: 'value') equals: ''.
+	self assert: (inputField getAttribute: 'value') isNil.
 	testDiv2 := driver findElementByID: 'testDiv2'.
-	self assert: (testDiv2 getAttribute: 'innerHTML') equals: '<p id="testDiv2p1" class="c2"></p><p id="testDiv2p2" class="c1"></p><p id="testDiv2p3" class="c1"></p>'
+	self assert: (testDiv2 getAttribute: 'innerHTML') isNil.

--- a/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testGetAttribute.st
+++ b/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testGetAttribute.st
@@ -1,8 +1,11 @@
 running
 testGetAttribute
 
-	| inputField |
+	| inputField testDiv2 |
 	inputField := driver findElementByID: 'inputField'.
 	self assert: (inputField getAttribute: 'type') = 'text'.
 	self assert: (inputField getAttribute: 'id') = 'inputField'.
 	self assert: (inputField getAttribute: 'attributeThatIsNotSpecified') isNil.
+	self assert: (inputField getAttribute: 'value') equals: ''.
+	testDiv2 := driver findElementByID: 'testDiv2'.
+	self assert: (testDiv2 getAttribute: 'innerHTML') equals: '<p id="testDiv2p1" class="c2"></p><p id="testDiv2p2" class="c1"></p><p id="testDiv2p3" class="c1"></p>'

--- a/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testGetProperty.st
+++ b/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testGetProperty.st
@@ -1,0 +1,12 @@
+running
+testGetProperty
+	| inputField testDiv2 |
+	inputField := driver findElementByID: 'inputField'.
+	self assert: (inputField getProperty: 'type') equals: 'text'.
+	self assert: (inputField getProperty: 'id') equals: 'inputField'.
+	self assert: (inputField getProperty: 'propertyThatIsNotSpecified') isNil.
+	self assert: (inputField getProperty: 'value') = ''.
+	inputField sendKeys: 'some test'.
+	self assert: (inputField getProperty: 'value') = 'some test'.
+	testDiv2 := driver findElementByID: 'testDiv2'.
+	self assert: (testDiv2 getProperty: 'innerHTML') equals: '<p id="testDiv2p1" class="c2"></p><p id="testDiv2p2" class="c1"></p><p id="testDiv2p3" class="c1"></p>'


### PR DESCRIPTION
Added the method `getProperty:` which is to be used to retrieve properties instead of attributes.
The change to chromedriver in issue #49 is a breaking change that modifies the semantics of the `getAttribute:` to be W3C compliant. This means tests need to use `getProperty:` rather than `getAttribute:` in many cases.