### PR TITLE
Baseline reload loop fix

### DIFF
--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -1,75 +1,89 @@
 baseline
 baseline: spec
-	
-	<baseline>
-	spec for: #common do: [
-		spec 
-			baseline: 'Seaside3' with: [
-				spec
-					loads: #('Tests' 'Zinc');
-					repository: 'github://SeasideSt/Seaside/repository'];
-			baseline: 'Ston' with: [
-				spec
-					repository: 'github://svenvc/ston/repository'].
-				
-		spec
-			package: 'Parasol-Core';
-			package: 'Parasol-Seaside' with: [ spec requires: #('Parasol-Core') ];
-			package: 'Parasol-Tests' with: [ spec requires: #('Seaside3' 'Parasol-Seaside') ];
-			package: 'Parasol-Convenience' with: [ spec requires: #('Parasol-Core') ].
-			
-		spec
-			group: 'default' with: #('Parasol-Seaside' 'Parasol-Convenience');
-			group: 'core' with: #('Parasol-Core' 'Parasol-Convenience');
-			group: 'tests' with: #('Parasol-Tests' 'default').
-	].
+  <baseline>
+  spec
+    for: #'common'
+    do: [
+      spec
+        baseline: 'Ston'
+        with: [ spec repository: 'github://svenvc/ston/repository' ].
+      spec
+        package: 'Parasol-Core';
+        package: 'Parasol-Seaside' with: [ spec requires: #('Parasol-Core') ];
+        package: 'Parasol-Tests' with: [ spec requires: #('Parasol-Seaside') ];
+        package: 'Parasol-Convenience'
+          with: [ spec requires: #('Parasol-Core') ].
+      spec
+        group: 'default' with: #('Parasol-Seaside' 'Parasol-Convenience');
+        group: 'core' with: #('Parasol-Core' 'Parasol-Convenience');
+        group: 'tests' with: #('Parasol-Tests' 'default') ].
+  spec
+    for: #'loadSeaside'
+    do: [
+      spec
+        baseline: 'Seaside3'
+        with: [
+          spec
+            loads: #('Tests' 'Zinc');
+            repository: 'github://SeasideSt/Seaside:master/repository' ].
+      spec
+        package: 'Parasol-Tests'
+        with: [ spec requires: #('Seaside3' 'Parasol-Seaside') ] ].
 
-	spec for: #squeak do: [
-		spec 
-			baseline: 'Seaside3' with: [
-				spec
-					loads: #('Tests' 'WebClient');
-					repository: 'github://SeasideSt/Seaside/repository'].
-				
-		spec
-			package: 'Parasol-Squeak';
-			package: 'Parasol-Core' with: [ spec includes: #('Parasol-Squeak') ].
-	].
-
-	spec for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x') do: [
-		spec
-			package: 'Parasol-Pharo' with: [ spec requires: #('Parasol-Core' 'Ston')];
-			package: 'Parasol-Core' with: [ spec includes:#('Parasol-Pharo') ].
-	].
-
-	spec for: #'pharo9.x' do: [
-		spec
-			package: 'Parasol-Pharo9' with: [ spec requires: #('Parasol-Core' 'Ston')];
-			package: 'Parasol-Core' with: [ spec includes:#('Parasol-Pharo9') ].
-	].
-	
-	spec for: #gemstone do: [
-		spec baseline: 'ZincHTTP'.
-			
-		spec
-			package: 'Parasol-GemStone';
-			package: 'Parasol-Core' with: [ spec includes:#('Parasol-GemStone'); requires: #('ZincHTTP') ].
-	].
-	
-	spec for: #'gs2.4.x' do: [
-		spec 
-			baseline: 'ZincHTTP' with: [
-				spec
-					className: 'BaselineOfZinc';
-					loads: 'Core';
-					repository: 'github://GsDevKit/zinc:2.3.2_gs2.4/repository'].
-	].
-		
-	spec for: #'gs3.x' do:[
-		spec 
-			baseline: 'ZincHTTP' with: [
-				spec
-					className: 'BaselineOfZincHTTPComponents';
-					loads: 'Core';
-					repository: 'github://GsDevKit/zinc:gs_master/repository'].
-	].
+  spec
+    for: #'squeak'
+    do: [
+      spec
+        baseline: 'Seaside3'
+        with: [
+          spec
+            loads: #('Tests' 'WebClient');
+            repository: 'github://SeasideSt/Seaside/repository' ].
+      spec
+        package: 'Parasol-Squeak';
+        package: 'Parasol-Core' with: [ spec includes: #('Parasol-Squeak') ] ].
+  spec
+    for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x')
+    do: [
+      spec
+        package: 'Parasol-Pharo'
+          with: [ spec requires: #('Parasol-Core' 'Ston') ];
+        package: 'Parasol-Core' with: [ spec includes: #('Parasol-Pharo') ] ].
+  spec
+    for: #'pharo9.x'
+    do: [
+      spec
+        package: 'Parasol-Pharo9'
+          with: [ spec requires: #('Parasol-Core' 'Ston') ];
+        package: 'Parasol-Core' with: [ spec includes: #('Parasol-Pharo9') ] ].
+  spec
+    for: #'gemstone'
+    do: [
+      spec baseline: 'ZincHTTP'.
+      spec
+        package: 'Parasol-GemStone';
+        package: 'Parasol-Core'
+          with: [
+              spec
+                includes: #('Parasol-GemStone');
+                requires: #('ZincHTTP') ] ].
+  spec
+    for: #'gs2.4.x'
+    do: [
+      spec
+        baseline: 'ZincHTTP'
+        with: [
+          spec
+            className: 'BaselineOfZinc';
+            loads: 'Core';
+            repository: 'github://GsDevKit/zinc:2.3.2_gs2.4/repository' ] ].
+  spec
+    for: #'gs3.x'
+    do: [
+      spec
+        baseline: 'ZincHTTP'
+        with: [
+          spec
+            className: 'BaselineOfZincHTTPComponents';
+            loads: 'Core';
+            repository: 'github://GsDevKit/zinc:gs_master/repository' ] ]

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/customProjectAttributes.st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/customProjectAttributes.st
@@ -1,0 +1,5 @@
+accessing
+customProjectAttributes
+  ^ (Smalltalk at: #'WAAdmin' ifAbsent: [ nil ])
+    ifNil: [ #(#'loadSeaside') ]
+    ifNotNil: [ #() ]


### PR DESCRIPTION
Extended fix for https://github.com/SeasideSt/Parasol/pull/52
On reload of Seaside, there was still a Metacello dependency loop.

Using custom project attributes to fix this: only load Seaside if it was not yet loaded.