### PR TITLE
Use ZnNewGemServer for testing in GemStone

### DIFF
--- a/repository/Parasol-GemStone.package/BPGemStonePlatform.class/instance/ensureSeasideServerStarted.st
+++ b/repository/Parasol-GemStone.package/BPGemStonePlatform.class/instance/ensureSeasideServerStarted.st
@@ -2,7 +2,7 @@ facade
 ensureSeasideServerStarted
   | gemserver |
   gemserver := (GemServer gemServerNamed: 'Seaside')
-    ifNil: [ (Smalltalk at: #'ZnSeasideGemServer') register: 'Seaside' on: {(self port)} ].
+    ifNil: [ (Smalltalk at: #'ZnSeasideNewGemServer') register: 'Seaside' on: {(self port)} ].
   gemserver restartGems.
   (Delay forSeconds: 1) wait.
   (gemserver waitForStartGems: 20)


### PR DESCRIPTION
This appears to be a fix for https://github.com/SeasideSt/Seaside/issues/1297
Although I'm not entirely clear on why the issue appears in the ZnGemServer, Dale's suggestion to use the ZnNewGemServer does prevent the issue. So, it appears to be at least better to move to it for Parasol and all Seaside testing to fix the builds (both issues https://github.com/SeasideSt/Seaside/issues/1281 and https://github.com/SeasideSt/Seaside/issues/1297)