### PR TITLE
Pharo13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.smalltalk }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, GemStone64-3.7.0, GemStone64-3.6.5, GemStone64-3.5.7 ]
+        smalltalk: [ Pharo64-12, Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, GemStone64-3.7.1, GemStone64-3.6.8, GemStone64-3.5.7 ]
         experimental: [ false ]
         include:
-          - smalltalk: Pharo64-12
+          - smalltalk: Pharo64-13
             experimental: true
           - smalltalk: Squeak64-5.3
             experimental: true

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/baseline..st
@@ -50,7 +50,7 @@ baseline: spec
           with: [ spec requires: #('Parasol-Core' 'Ston') ];
         package: 'Parasol-Core' with: [ spec includes: #('Parasol-Pharo') ] ].
   spec
-    for: #('pharo9.x' 'pharo10.x' 'pharo11.x' 'pharo12.x')
+    for: #('pharo9.x' 'pharo10.x' 'pharo11.x' 'pharo12.x' 'pharo13.x')
     do: [
       spec
         package: 'Parasol-Pharo9'

--- a/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/customProjectAttributes.st
+++ b/repository/BaselineOfParasol.package/BaselineOfParasol.class/instance/customProjectAttributes.st
@@ -1,5 +1,6 @@
 accessing
 customProjectAttributes
+
   ^ (Smalltalk at: #'WAAdmin' ifAbsent: [ nil ])
-    ifNil: [ #(#'loadSeaside') ]
-    ifNotNil: [ #() ]
+    	ifNil: [ #(#'loadSeaside') ]
+    	ifNotNil: [ #() ]

--- a/repository/BaselineOfParasol.package/monticello.meta/categories.st
+++ b/repository/BaselineOfParasol.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #BaselineOfParasol!
+self packageOrganizer ensurePackage: #BaselineOfParasol withTags: #()!


### PR DESCRIPTION
Adds Pharo 13 to the baseline and CI builds. 
Also updates the tested platforms line-up in the CI.