### PR TITLE
Use Duration>>asMilliseconds instead of Duration>>asMilliSeconds 

### DIFF
--- a/repository/Parasol-Core.package/BPTimeouts.class/instance/implicitlyWait..st
+++ b/repository/Parasol-Core.package/BPTimeouts.class/instance/implicitlyWait..st
@@ -7,5 +7,5 @@ implicitlyWait: duration
 	driver
 		httpPostHandleResponse: driver baseSessionURL , 'timeouts'
 		jsonData: (Dictionary new
-			at: 'implicit' put: duration asMilliSeconds;
+			at: 'implicit' put: duration asMilliseconds;
 			yourself)


### PR DESCRIPTION
Duration>>asMilliseconds is tested by Grease and thus verified to be present. 
