### PR TITLE
Ability to override the baseURL that is set in a Parasol testcase

### DIFF
--- a/repository/Parasol-Core.package/BPWebDriverTestCase.class/class/baseURLOverride..st
+++ b/repository/Parasol-Core.package/BPWebDriverTestCase.class/class/baseURLOverride..st
@@ -1,0 +1,6 @@
+accessing
+baseURLOverride: aString
+
+	"When set, this will be used as the baseURL rather than what the code mentions. 
+	Useful if you want to run the same testcases in build environments where the server url is not localhost."
+	BaseURLOverride := aString

--- a/repository/Parasol-Core.package/BPWebDriverTestCase.class/instance/baseURL.st
+++ b/repository/Parasol-Core.package/BPWebDriverTestCase.class/instance/baseURL.st
@@ -1,4 +1,5 @@
 running
 baseURL
-
-	^'http://localhost:' , BPSmalltalkPlatform current port printString , '/'
+	
+	^ BaseURLOverride ifNil:[
+		'http://localhost:', BPSmalltalkPlatform current port printString , '/' ]

--- a/repository/Parasol-Core.package/BPWebDriverTestCase.class/properties.json
+++ b/repository/Parasol-Core.package/BPWebDriverTestCase.class/properties.json
@@ -4,7 +4,9 @@
 	"category" : "Parasol-Core",
 	"classinstvars" : [ ],
 	"pools" : [ ],
-	"classvars" : [ ],
+	"classvars" : [
+		"BaseURLOverride"
+	],
 	"instvars" : [
 		"driver",
 		"screenshotCounter"

--- a/repository/Parasol-Tests.package/BPWindowTestCase.class/instance/testPosition.st
+++ b/repository/Parasol-Tests.package/BPWindowTestCase.class/instance/testPosition.st
@@ -2,6 +2,8 @@ running
 testPosition
 	
 	driver manage window setPosition: 25@30.
+	self waitUntil: [ driver manage window getPosition = (25@30) ] ifTimeout: [ self fail ].
 	self assert: driver manage window getPosition = (25@30).
 	driver manage window setPosition: 40@50.
-	self assert: driver manage window getPosition = (40@50).
+	self waitUntil: [ driver manage window getPosition = (40@50) ] ifTimeout: [ self fail ].
+	self assert: driver manage window getPosition = (40@50)

--- a/repository/Parasol-Tests.package/BPWindowTestCase.class/instance/testReference.st
+++ b/repository/Parasol-Tests.package/BPWindowTestCase.class/instance/testReference.st
@@ -10,6 +10,7 @@ testReference
 	window1 := driver manage window.
 	window1 setPosition: 30@35.
 	window1 setSize: 600@500.
+	self waitUntil: [ window1 getPosition = (30@35) ] ifTimeout: [ self fail ].
 	self assert: window1 getPosition = (30@35).
 	self assert: window1 getSize = (600@500).
 	
@@ -29,6 +30,7 @@ testReference
 	self deny: window1 getSize = (600@500).
 	driver switchTo window: windowHandle1.
 	self assert: driver getWindowHandle equals: windowHandle1.
+	self waitUntil: [ window1 getPosition = (30@35) ] ifTimeout: [ self fail ].
 	self assert: window1 getPosition = (30@35).
 	self assert: window1 getSize = (600@500).
 	self assert: window2 getPosition = (30@35).

--- a/repository/Parasol-Tests.package/BPWindowTestCase.class/instance/testSize.st
+++ b/repository/Parasol-Tests.package/BPWindowTestCase.class/instance/testSize.st
@@ -2,6 +2,8 @@ running
 testSize
 
 	driver manage window setSize: 500@600.
+	self waitUntil: [ driver manage window getSize = (500@600) ] ifTimeout: [ self fail ].
 	self assert: driver manage window getSize = (500@600).
 	driver manage window setSize: 600@500.
+	self waitUntil: [ driver manage window getSize = (600@500) ] ifTimeout: [ self fail ].
 	self assert: driver manage window getSize = (600@500).

--- a/repository/Parasol-Tests.package/monticello.meta/categories.st
+++ b/repository/Parasol-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Parasol-Tests'!
+self packageOrganizer ensurePackage: #'Parasol-Tests' withTags: #()!


### PR DESCRIPTION
Use case: the same testcases can be run in another configuration where Selenium+Chrome are not running on the localhost. For example, when a docker container is setup with Selenium. In such a case, the browser will need to be pointed to a different URL, which is hard to determine programmatically in every situation.

By allowing to override the value returned by `BPWebDriverTestCase>>#baseURL`, it is easier to run the same testcases in different configurations. The build system or the developer can initialize it with the correct value without changing the source code.

I also changed a couple of tests that were failing in VAST, so they run more reliably.