### PR TITLE
Update testSendKeys.st

### DIFF
--- a/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testSendKeys.st
+++ b/repository/Parasol-Tests.package/BPWebElementTestCase.class/instance/testSendKeys.st
@@ -4,6 +4,7 @@ testSendKeys
 	| inputElement submitButton submittedValue |
 	self assert: self componentUnderTest inputFieldValue isNil.
 	inputElement := driver findElementByID: 'inputField'.
+	inputElement click.
 	inputElement sendKeys: 'foo' ,
 		(String with: BPKeys shift) , 'bar' ,
 		(String with: BPKeys shift) , 'baz' ,


### PR DESCRIPTION
Clicking on the element should make sure that it is selected before sending keys to the element.