### PR TITLE
Adapt #moveToElement:offset: on BPActions to changes in computation of an element’s in-view center point in chromedriver

### DIFF
--- a/repository/Parasol-Core.package/BPActions.class/instance/moveToElement.offset..st
+++ b/repository/Parasol-Core.package/BPActions.class/instance/moveToElement.offset..st
@@ -12,53 +12,29 @@ moveToElement: webElement offset: offset
 	is constructed, rather than when the move mouse action is executed; in a complicated
 	BPCompositeAction, the element's in-view center point may change because of an
 	earlier action. The script that is used is (based on) the one used in chromedriver
-	to compute an element's in-view center point [2]. It may not be compatible with the
-	interpretation of in-view center point in other WebDriver implementations [3].
+	to compute an element's in-view center point [2].
 	
 	[1] https://github.com/w3c/webdriver/issues/1171
-	[2] https://chromium.googlesource.com/chromium/src/+/09b268ecde9156723d5ad561de298789b70dffa8/chrome/test/chromedriver/js/get_element_location.js#11
-	[3] https://bugs.chromium.org/p/chromedriver/issues/detail?id=3190"
+	[2] https://chromium.googlesource.com/chromium/src/+/093f9b4be6509dc8df62dbd46b8ecc70f2dcf391/chrome/test/chromedriver/js/get_element_location.js#66"
 
 	| translatedOffsetCoordinates translatedOffset |
 	
 	translatedOffsetCoordinates := driver executeScript: '
 		return (function(element, originalOffsetX, originalOffsetY) {
+			function getFirstNonZeroWidthHeightRect(rects) {
+				for (var i = 0; i < rects.length; i++) {
+					var rect = rects[i];
+					if (rect.height > 0 && rect.width > 0)
+						return rect;
+				}
+				return rects[0];
+			}
 			var rectangles = element.getClientRects();
-			var rect = rectangles[0];
+			var rect = getFirstNonZeroWidthHeightRect(rectangles);
 			var left = Math.max(0, rect.left);
 			var right = Math.min(window.innerWidth, rect.right);
 			var top = Math.max(0, rect.top);
 			var bottom = Math.min(window.innerHeight, rect.bottom);
-			while (element.parentElement != null &&
-				 element.parentElement != document.body &&
-				 element.parentElement.getClientRects().length > 0) {
-			  var parentStyle = window.getComputedStyle(element.parentElement);
-			  var overflow = parentStyle.getPropertyValue("overflow");
-			  var overflowX = parentStyle.getPropertyValue("overflow-x");
-			  var overflowY = parentStyle.getPropertyValue("overflow-y");
-			  var parentRect = element.parentElement.getClientRects()[0];
-			  if (parentRect.right > left && parentRect.bottom > top &&
-				right > parentRect.left && bottom > parentRect.top) {
-				if (overflow == "auto" || overflow == "scroll" || overflow == "hidden") {
-				left = Math.max(left, parentRect.left);
-				right = Math.min(right, parentRect.right);
-				top = Math.max(top, parentRect.top);
-				bottom = Math.min(bottom, parentRect.bottom);
-				} else {
-				if (overflowX == "auto" || overflowX == "scroll" ||
-					overflowX == "hidden") {
-				  left = Math.max(left, parentRect.left);
-				  right = Math.min(right, parentRect.right);
-				}
-				if (overflowY == "auto" || overflowY == "scroll" ||
-					overflowY == "hidden") {
-				  top = Math.max(top, parentRect.top);
-				  bottom = Math.min(bottom, parentRect.bottom);
-				}
-				}
-			  }
-			  element = element.parentElement;
-			}
 			var x = 0.5 * (left + right);
 			var y = 0.5 * (top + bottom);
 			return [ (Math.floor(rect.left) + originalOffsetX) - Math.floor(x), (Math.floor(rect.top) + originalOffsetY) - Math.floor(y) ];


### PR DESCRIPTION
This pull request adapts #moveToElement:offset: on BPActions to changes in computation of an element’s in-view center point in chromedriver (in: https://chromium.googlesource.com/chromium/src/+/73e864f668327767 and https://chromium.googlesource.com/chromium/src/+/a436a4700effdcb2).